### PR TITLE
14자리 카드번호 지원

### DIFF
--- a/src/Iamport.RestApi/Models/CreditCardNumberAttribute.cs
+++ b/src/Iamport.RestApi/Models/CreditCardNumberAttribute.cs
@@ -10,7 +10,7 @@ namespace Iamport.RestApi.Models
         /// <summary>
         /// 기본 아임포트 신용카드 번호 형식으로 초기화합니다.
         /// </summary>
-        public CreditCardNumberAttribute() : base(@"^\d{4}-\d{4}-\d{4}-\d{3,4}$")
+        public CreditCardNumberAttribute() : base(@"^\d{4}-\d{4}-\d{4}-\d{2,4}$")
         {
         }
     }

--- a/test/Iamport.RestApi.Tests/Models/CreditCardNumberAttributeTest.cs
+++ b/test/Iamport.RestApi.Tests/Models/CreditCardNumberAttributeTest.cs
@@ -15,6 +15,7 @@ namespace Iamport.RestApi.Tests.Models
         [Theory]
         [InlineData("1234-1234-1234-1234")]
         [InlineData("1234-1234-1234-123")]
+        [InlineData("1234-1234-1234-12")]
         public void Valid_credit_card_number(string number)
         {
             var foo = new Foo { Number = number };


### PR DESCRIPTION
다이너스 클럽의 경우 14자리 카드번호를 가지고 있기에 14자리에 대한 지원을 추가합니다.